### PR TITLE
Create Configurations for OpenCHAMI on vTDS

### DIFF
--- a/core-configs/vtds-openChami-gcp.yaml
+++ b/core-configs/vtds-openChami-gcp.yaml
@@ -131,10 +131,18 @@ cluster:
     management_node:
       # A node count of 1 creates a single management node.
       node_count: 1
+      # These virtual machine settings make a management node that is
+      # not very big and can handle running OpenCHAMI without issues.
+      virtual_machine:
+        cpu_count: 4
+        memory_size_mib: 8192
     compute_node:
-      # A node count of 0 prevents compute nodes from being
-      # created. This is the simplest version of OpenCHAMI and will use
-      # the RIE RedFish emulator to simulate the existence of compute
-      # nodes. This can be increased to four for every virtual blade in
-      # the cluster.
-      node_count: 0
+      # A node count of 4 creates 4 virtual compute nodes running on the
+      # same Virtual Blade (GCP instance) as the management node, which
+      # provides a good minimal environment for an end-to end test of
+      # creating, booting, initializing, and power managing compute
+      # nodes. Larger node counts require more Virtual Blades.
+      node_count: 4
+application:
+  deployment:
+    mode: quadlet

--- a/layers/application/ubuntu/application-ubuntu-openChami.yaml
+++ b/layers/application/ubuntu/application-ubuntu-openChami.yaml
@@ -20,8 +20,6 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-#
-# Nothing here yet. Come back later for the config
 application:
   discovery_networks:
     internal:
@@ -31,5 +29,5 @@ application:
       network_cidr: null
       network_name: hwmgtnet
   host:
-    network: mgmtnet
+    network: compnet
     node_class: management_node

--- a/layers/cluster/kvm/cluster-kvm-openChami.yaml
+++ b/layers/cluster/kvm/cluster-kvm-openChami.yaml
@@ -23,6 +23,15 @@
 #
 # Cluster layer configuration for deploying OpenCHAMI on vTDS
 cluster:
+  # Configure the name server list on the host network. That way, all
+  # nodes get a name server from the start. It might make sense to do
+  # this differently for compute nodes for booting, but I think that
+  # will be okay because of DHCP.
+  host_blade_network:
+    address_families:
+      ipv4:
+        name_servers:
+          - 169.254.169.254
   networks:
     management_network:
       network_name: mgmtnet
@@ -39,17 +48,15 @@ cluster:
           family: AF_INET
           cidr: 10.1.1.0/24
           gateway: 10.1.1.1
-          name_servers:
-            - 169.254.169.254
           connected_blades:
             - blade_class: host-blade
               addresses:
                 - 10.1.1.1
               dhcp_server_instance: 0
           dhcp:
-            enabled: true
+            enabled: false
             pools:
-              - start: 10.1.1.10
+              - start: 10.1.1.64
                 end: 10.1.1.254
     compute_network:
       network_name: compnet
@@ -65,9 +72,8 @@ cluster:
         ipv4:
           family: AF_INET
           cidr: 10.2.1.0/24
-          gateway: 10.2.1.1
-          name_servers:
-            - 169.254.169.254
+          gateway: null
+          name_servers: []
           connected_blades:
             - blade_class: host-blade
               addresses:
@@ -76,7 +82,7 @@ cluster:
           dhcp:
             enabled: true
             pools:
-              - start: 10.2.1.10
+              - start: 10.2.1.32
                 end: 10.2.1.254
     hardware_network:
       network_name: hwmgtnet
@@ -93,8 +99,7 @@ cluster:
           family: AF_INET
           cidr: 10.3.1.0/24
           gateway: null
-          name_servers:
-            - 169.254.169.254
+          name_servers: []
           connected_blades:
             - blade_class: host-blade
               addresses:
@@ -116,9 +121,9 @@ cluster:
                 - 10.3.1.16
               dhcp_server_instance: 0
           dhcp:
-            enabled: true
+            enabled: false
             pools:
-              - start: 10.3.1.16
+              - start: 10.3.1.64
                 end: 10.3.1.254
   node_classes:
     management_node:
@@ -147,13 +152,36 @@ cluster:
           addr_info:
             ipv4:
               family: AF_INET
-              mode: dynamic
+              mode: static
+              addresses:
+                - 10.1.1.2
+                - 10.1.1.3
+                - 10.1.1.4
+                - 10.1.1.5
+                - 10.1.1.6
+                - 10.1.1.7
+                - 10.1.1.8
+                - 10.1.1.9
         hardware_network:
           cluster_network: hwmgtnet
           addr_info:
             ipv4:
               family: AF_INET
-              mode: dynamic
+              mode: static
+              addresses:
+                - 10.3.1.24
+                - 10.3.1.25
+                - 10.3.1.26
+                - 10.3.1.27
+                - 10.3.1.28
+                - 10.3.1.29
+                - 10.3.1.30
+                - 10.3.1.31
+      application_metadata:
+        # node_role is either management or managed. Managed nodes will
+        # be included in discovery data and assigned NIDs. Management
+        # nodes will not.
+        node_role: management
     compute_node:
       pure_base_class: false
       parent_class: rocky_linux_node
@@ -187,22 +215,22 @@ cluster:
         # with node xnames. Blade xnames are currently defined there up
         # to 16 blades (support for 64 nodes)
         node_names:
-          - x1c0s0b0n1
-          - x1c0s0b0n2
-          - x1c0s0b0n3
-          - x1c0s0b0n4
-          - x1c0s1b0n0
-          - x1c0s1b0n1
-          - x1c0s1b0n2
-          - x1c0s1b0n3
-          - x1c0s2b0n0
-          - x1c0s2b0n1
-          - x1c0s2b0n2
-          - x1c0s2b0n3
-          - x1c0s3b0n0
-          - x1c0s3b0n1
-          - x1c0s3b0n2
-          - x1c0s3b0n3
+          - x2000c0s0b0n1
+          - x2000c0s0b0n2
+          - x2000c0s0b0n3
+          - x2000c0s0b0n4
+          - x2000c0s1b0n0
+          - x2000c0s1b0n1
+          - x2000c0s1b0n2
+          - x2000c0s1b0n3
+          - x2000c0s2b0n0
+          - x2000c0s2b0n1
+          - x2000c0s2b0n2
+          - x2000c0s2b0n3
+          - x2000c0s3b0n0
+          - x2000c0s3b0n1
+          - x2000c0s3b0n2
+          - x2000c0s3b0n3
       host_naming:
         base_name: compute
       network_interfaces:
@@ -211,10 +239,53 @@ cluster:
           addr_info:
             ipv4:
               family: AF_INET
-              mode: dynamic
+              mode: reserved
+              addresses:
+                - 10.2.1.32
+                - 10.2.1.33
+                - 10.2.1.34
+                - 10.2.1.35
+                - 10.2.1.36
+                - 10.2.1.37
+                - 10.2.1.38
+                - 10.2.1.39
+                - 10.2.1.40
+                - 10.2.1.41
+                - 10.2.1.42
+                - 10.2.1.43
+                - 10.2.1.44
+                - 10.2.1.45
+                - 10.2.1.46
+                - 10.2.1.47
         management_network:
           cluster_network: mgmtnet
           addr_info:
             ipv4:
               family: AF_INET
-              mode: dynamic
+              mode: reserved
+              addresses:
+                - 10.1.1.32
+                - 10.1.1.33
+                - 10.1.1.34
+                - 10.1.1.35
+                - 10.1.1.36
+                - 10.1.1.37
+                - 10.1.1.38
+                - 10.1.1.39
+                - 10.1.1.40
+                - 10.1.1.41
+                - 10.1.1.42
+                - 10.1.1.43
+                - 10.1.1.44
+                - 10.1.1.45
+                - 10.1.1.46
+                - 10.1.1.47
+      application_metadata:
+        # node_role is either management or managed. Managed nodes will
+        # be included in discovery data and assigned NIDs. Management
+        # nodes will not.
+        node_role: managed
+        # node_group identifies a group of nodes (for example 'compute')
+        # that the nodes in this class belong to. Used in generating
+        # static discovery data.
+        node_group: compute

--- a/layers/cluster/kvm/cluster-kvm-openChami.yaml
+++ b/layers/cluster/kvm/cluster-kvm-openChami.yaml
@@ -215,10 +215,10 @@ cluster:
         # with node xnames. Blade xnames are currently defined there up
         # to 16 blades (support for 64 nodes)
         node_names:
+          - x2000c0s0b0n0
           - x2000c0s0b0n1
           - x2000c0s0b0n2
           - x2000c0s0b0n3
-          - x2000c0s0b0n4
           - x2000c0s1b0n0
           - x2000c0s1b0n1
           - x2000c0s1b0n2

--- a/layers/cluster/kvm/cluster-kvm-openChami.yaml
+++ b/layers/cluster/kvm/cluster-kvm-openChami.yaml
@@ -184,7 +184,7 @@ cluster:
         node_role: management
     compute_node:
       pure_base_class: false
-      parent_class: rocky_linux_node
+      parent_class: rocky_net_boot
       # No compute nodes by default. Increase this number to have
       # compute nodes in the system. Since the host blade capacity is 4
       # compute nodes, if you add more than 4 compute nodes, you will
@@ -193,6 +193,9 @@ cluster:
       node_count: 0
       virtual_machine:
         cpu_count: 1
+        boot_info:
+          interfaces:
+            - management_network
       host_blade:
         blade_class: host-blade
         instance_capacity: 4

--- a/layers/cluster/kvm/cluster-kvm-openChami.yaml
+++ b/layers/cluster/kvm/cluster-kvm-openChami.yaml
@@ -80,10 +80,19 @@ cluster:
                 - 10.2.1.1
               dhcp_server_instance: 0
           dhcp:
-            enabled: true
+            enabled: false
             pools:
               - start: 10.2.1.32
                 end: 10.2.1.254
+      application_metadata:
+        # For now, define a single pool for CoreDHCP to use in its
+        # config. We can revisit this later. We can also revisit whether
+        # we want an API into Virtual Networks for getting DHCP
+        # configuration from the network, which would be a bit cleaner.
+        coredhcp:
+          pool:
+            start: 10.2.1.32
+            end: 10.2.1.254
     hardware_network:
       network_name: hwmgtnet
       tunnel_id: 30
@@ -138,10 +147,11 @@ cluster:
       node_naming:
         base_name: management
         # In this configuration, there is one management node and it
-        # lives on the same node as the first 4 compute nodes. Because
-        # of this, the cabinet (x), chassis (c), shelf (s), and
-        # blade (b) numbers need to match those of the compute nodes
-        # and it will show up as the first node on the blade (n0)
+        # lives on the same node as the first 4 compute nodes, but we
+        # don't manage it, so it is given a distinct xname in cabinet 1
+        # which does not contain any managed nodes. This is a bit of a
+        # hack, but it keeps it out of the way and makes it unlikely to
+        # be accidentally power cycled.
         node_names:
           - x1c0s0b0n0
       host_naming:
@@ -162,6 +172,21 @@ cluster:
                 - 10.1.1.7
                 - 10.1.1.8
                 - 10.1.1.9
+        compute_network:
+          cluster_network: compnet
+          addr_info:
+            ipv4:
+              family: AF_INET
+              mode: static
+              addresses:
+                - 10.2.1.2
+                - 10.2.1.3
+                - 10.2.1.4
+                - 10.2.1.5
+                - 10.2.1.6
+                - 10.2.1.7
+                - 10.2.1.8
+                - 10.2.1.9
         hardware_network:
           cluster_network: hwmgtnet
           addr_info:
@@ -182,6 +207,8 @@ cluster:
         # be included in discovery data and assigned NIDs. Management
         # nodes will not.
         node_role: management
+        # Specify which network is the cluster network for this node
+        cluster_net_interface: compnet
     compute_node:
       pure_base_class: false
       parent_class: rocky_net_boot
@@ -195,7 +222,7 @@ cluster:
         cpu_count: 1
         boot_info:
           interfaces:
-            - management_network
+            - compute_network
       host_blade:
         blade_class: host-blade
         instance_capacity: 4
@@ -216,24 +243,25 @@ cluster:
         # This needs to be coordinated with the application metadata in
         # the provider layer config to make sure Blade xnames match up
         # with node xnames. Blade xnames are currently defined there up
-        # to 16 blades (support for 64 nodes)
+        # to 16 blades (support for 64 nodes). Currently defined 16
+        # compute nodes (four per blade 'n0' through 'n3').
         node_names:
           - x2000c0s0b0n0
           - x2000c0s0b0n1
           - x2000c0s0b0n2
           - x2000c0s0b0n3
-          - x2000c0s1b0n0
-          - x2000c0s1b0n1
-          - x2000c0s1b0n2
-          - x2000c0s1b0n3
-          - x2000c0s2b0n0
-          - x2000c0s2b0n1
-          - x2000c0s2b0n2
-          - x2000c0s2b0n3
-          - x2000c0s3b0n0
-          - x2000c0s3b0n1
-          - x2000c0s3b0n2
-          - x2000c0s3b0n3
+          - x2000c0s0b1n0
+          - x2000c0s0b1n1
+          - x2000c0s0b1n2
+          - x2000c0s0b1n3
+          - x2000c0s0b2n0
+          - x2000c0s0b2n1
+          - x2000c0s0b2n2
+          - x2000c0s0b2n3
+          - x2000c0s0b3n0
+          - x2000c0s0b3n1
+          - x2000c0s0b3n2
+          - x2000c0s0b3n3
       host_naming:
         base_name: compute
       network_interfaces:
@@ -260,29 +288,6 @@ cluster:
                 - 10.2.1.45
                 - 10.2.1.46
                 - 10.2.1.47
-        management_network:
-          cluster_network: mgmtnet
-          addr_info:
-            ipv4:
-              family: AF_INET
-              mode: reserved
-              addresses:
-                - 10.1.1.32
-                - 10.1.1.33
-                - 10.1.1.34
-                - 10.1.1.35
-                - 10.1.1.36
-                - 10.1.1.37
-                - 10.1.1.38
-                - 10.1.1.39
-                - 10.1.1.40
-                - 10.1.1.41
-                - 10.1.1.42
-                - 10.1.1.43
-                - 10.1.1.44
-                - 10.1.1.45
-                - 10.1.1.46
-                - 10.1.1.47
       application_metadata:
         # node_role is either management or managed. Managed nodes will
         # be included in discovery data and assigned NIDs. Management
@@ -292,3 +297,5 @@ cluster:
         # that the nodes in this class belong to. Used in generating
         # static discovery data.
         node_group: compute
+        # Which network is the cluster network for this node
+        cluster_net_interface: compnet

--- a/layers/platform/ubuntu/platform-ubuntu-openChami.yaml
+++ b/layers/platform/ubuntu/platform-ubuntu-openChami.yaml
@@ -22,4 +22,27 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Platform layer configuration for the FSM to SCP connectivity demo
-platform: {}
+platform:
+  packages:
+    openchami_dns_support:
+      # We use dnsMasq running on the blades (at least the blade hosting
+      # the head node) to serve the FQDN of the head-node and to forward
+      # external lookups to the GCP metadata / DNS server. It will be
+      # enabled once it is configured on the blades where it is running.
+      blade_classes: null
+      packages:
+        - dnsmasq
+      preconfig_settings: []
+      services_enable: []
+      services_disable:
+        - dnsmasq
+    nat_support:
+      # The blades need to run NAT to support forwarding outside the
+      # cluster. The nftables packages gives us the ability to manage
+      # that.
+      blade_classes: null
+      packages:
+        - nftables
+      preconfig_settings: []
+      services_enable: []
+      services_disable: []

--- a/layers/provider/gcp/provider-gcp-openChami.yaml
+++ b/layers/provider/gcp/provider-gcp-openChami.yaml
@@ -83,25 +83,25 @@ provider:
         # xnames in OpenCHAMI). These should be the parent names for the
         # Virtual Nodes that reside on the respective Virtual Blades.
         #
-        # The agreed upon scheme here is that each blade is Blade 0 (bo)
-        # in its respective Shelf (s0 through s15).
+        # The agreed upon scheme here is that blades are 0 through 3
+        # in their respective Shelves..
         xnames:
           - x2000c0s0b0
+          - x2000c0s0b1
+          - x2000c0s0b2
+          - x2000c0s0b3
           - x2000c0s1b0
+          - x2000c0s1b1
+          - x2000c0s1b2
+          - x2000c0s1b3
           - x2000c0s2b0
+          - x2000c0s2b1
+          - x2000c0s2b2
+          - x2000c0s2b3
           - x2000c0s3b0
-          - x2000c0s4b0
-          - x2000c0s5b0
-          - x2000c0s6b0
-          - x2000c0s7b0
-          - x2000c0s8b0
-          - x2000c0s9b0
-          - x2000c0s10b0
-          - x2000c0s11b0
-          - x2000c0s12b0
-          - x2000c0s13b0
-          - x2000c0s14b0
-          - x2000c0s15b0
+          - x2000c0s3b1
+          - x2000c0s3b2
+          - x2000c0s3b3
     # Compute blade. This is an alternative blade class that can host
     # Compute nodes. Using Compute Blades for systems with more than 4
     # compute nodes allows the Managment node to live on a different
@@ -157,22 +157,22 @@ provider:
         # xnames in OpenCHAMI). These should be the parent names for the
         # Virtual Nodes that reside on the respective Virtual Blades.
         #
-        # The agreed upon scheme here is that each blade is Blade 0 (bo)
-        # in its respective Shelf (s0 through s15).
+        # The agreed upon scheme here is that blades are 0 through 3 and
+        # in their respective shelves.
         xnames:
-          - x2c0s0b0
-          - x2c0s1b0
-          - x2c0s2b0
-          - x2c0s3b0
-          - x2c0s4b0
-          - x2c0s5b0
-          - x2c0s6b0
-          - x2c0s7b0
-          - x2c0s8b0
-          - x2c0s9b0
-          - x2c0s10b0
-          - x2c0s11b0
-          - x2c0s12b0
-          - x2c0s13b0
-          - x2c0s14b0
-          - x2c0s15b0
+          - x4000c0s0b0
+          - x4000c0s0b1
+          - x4000c0s0b2
+          - x4000c0s0b3
+          - x4000c0s1b0
+          - x4000c0s1b1
+          - x4000c0s1b2
+          - x4000c0s1b3
+          - x4000c0s2b0
+          - x4000c0s2b1
+          - x4000c0s2b2
+          - x4000c0s2b3
+          - x4000c0s3b0
+          - x4000c0s3b1
+          - x4000c0s3b2
+          - x4000c0s3b3

--- a/layers/provider/gcp/provider-gcp-openChami.yaml
+++ b/layers/provider/gcp/provider-gcp-openChami.yaml
@@ -43,7 +43,11 @@ provider:
         of blade interconnect inheritance.
       routes: []
   virtual_blades:
-    # Test basic inheritance
+    # Host blade. This is normally the host blade class for both Management
+    # and Compute nodes. By doing it this way, we can create a vTDS with
+    # a management node and up to 4 compute nodes on a single GCP
+    # instance, thereby keeping costs down for small development and
+    # test systems.
     host-blade:
       vm:
         machine_type: n1-standard-16
@@ -82,19 +86,93 @@ provider:
         # The agreed upon scheme here is that each blade is Blade 0 (bo)
         # in its respective Shelf (s0 through s15).
         xnames:
-          - x1c0s0b0
-          - x1c0s1b0
-          - x1c0s2b0
-          - x1c0s3b0
-          - x1c0s4b0
-          - x1c0s5b0
-          - x1c0s6b0
-          - x1c0s7b0
-          - x1c0s8b0
-          - x1c0s9b0
-          - x1c0s10b0
-          - x1c0s11b0
-          - x1c0s12b0
-          - x1c0s13b0
-          - x1c0s14b0
-          - x1c0s15b0
+          - x2000c0s0b0
+          - x2000c0s1b0
+          - x2000c0s2b0
+          - x2000c0s3b0
+          - x2000c0s4b0
+          - x2000c0s5b0
+          - x2000c0s6b0
+          - x2000c0s7b0
+          - x2000c0s8b0
+          - x2000c0s9b0
+          - x2000c0s10b0
+          - x2000c0s11b0
+          - x2000c0s12b0
+          - x2000c0s13b0
+          - x2000c0s14b0
+          - x2000c0s15b0
+    # Compute blade. This is an alternative blade class that can host
+    # Compute nodes. Using Compute Blades for systems with more than 4
+    # compute nodes allows the Managment node to live on a different
+    # set of blades from the Compute nodes and allows up to 16 Compute
+    # nodes to be configured into the vTDS cluster. To use Compute
+    # blades for Compute nodes, set the host blade blade class to
+    # 'compute-blade' instead of 'host-blade' in the cluster
+    # configuration of your configuration overlay and set the number of
+    # compute blade instances to whatever is appropriate for your
+    # cluster in the platform configuration, something like:
+    #
+    # provider:
+    #   virtual_blades:
+    #     compute-blade:
+    #       count: 1
+    # cluster:
+    #   node_classes:
+    #     compute_node:
+    #       host_blade:
+    #         blade_class: compute-blade
+    compute-blade:
+      vm:
+        machine_type: n1-standard-16
+        boot_disk:
+          disk_size_gb: 1000
+      parent_class: base-blade
+      pure_base_class: false
+      blade_interconnect:
+        subnetwork: "blade-interconnect"
+        ip_addrs:
+        - 10.255.1.1
+        - 10.255.1.2
+        - 10.255.1.3
+        - 10.255.1.4
+        - 10.255.1.5
+        - 10.255.1.6
+        - 10.255.1.7
+        - 10.255.1.8
+        - 10.255.1.9
+        - 10.255.1.10
+        - 10.255.1.11
+        - 10.255.1.12
+        - 10.255.1.13
+        - 10.255.1.14
+        - 10.255.1.15
+        - 10.255.1.16
+      count: 0
+      name_prefix: "compute-blade"
+      hostname: compute-blade
+      # OpenCHAMI Application metadata for the Virtual Blades
+      application_metadata:
+        # Map these xnames onto the Cluster Layer node names (which are
+        # xnames in OpenCHAMI). These should be the parent names for the
+        # Virtual Nodes that reside on the respective Virtual Blades.
+        #
+        # The agreed upon scheme here is that each blade is Blade 0 (bo)
+        # in its respective Shelf (s0 through s15).
+        xnames:
+          - x2c0s0b0
+          - x2c0s1b0
+          - x2c0s2b0
+          - x2c0s3b0
+          - x2c0s4b0
+          - x2c0s5b0
+          - x2c0s6b0
+          - x2c0s7b0
+          - x2c0s8b0
+          - x2c0s9b0
+          - x2c0s10b0
+          - x2c0s11b0
+          - x2c0s12b0
+          - x2c0s13b0
+          - x2c0s14b0
+          - x2c0s15b0


### PR DESCRIPTION
## Summary and Scope

This PR updates the configuration for OpenCHAMI on vTDS to cover all the configuration needed to bring up an OpenCHAMI managed vTDS cluster.

## Issues and Related PRs

* Related to  [VSHA-697](https://jira-pro.it.hpe.com:8443/browse/VSHA-697)

## Testing

This is the configuration used to deploy OpenCHAMI on vTDS for all of the development of VSHA-697.