### PR TITLE
Create Configuration for a Test Runner vTDS System

### DIFF
--- a/core-configs/vtds-openchami-test-runner.yaml
+++ b/core-configs/vtds-openchami-test-runner.yaml
@@ -1,0 +1,123 @@
+#
+# MIT License
+#
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# A core configuration for deploying a test-runner vTDS system for use
+# in OpenCHAMI automated testing.
+core:
+  layers:
+    base:
+      package: vtds-base
+      module: vtds_base
+      source_type: git
+      metadata:
+        url: "git@github.com:Cray-HPE/vtds-base.git"
+        version: main
+    core:
+      package: vtds-core
+      module: vtds_core
+      source_type: git
+      metadata:
+        url: "git@github.com:Cray-HPE/vtds-core.git"
+        version: main
+    provider:
+      package: vtds-provider-gcp
+      module: vtds_provider_gcp
+      source_type: git
+      metadata:
+        url: "git@github.com:Cray-HPE/vtds-provider-gcp.git"
+        version: main
+    platform:
+      package: vtds-platform-ubuntu
+      module: vtds_platform_ubuntu
+      source_type: git
+      metadata:
+        url: "git@github.com:Cray-HPE/vtds-platform-ubuntu.git"
+        version: main
+    cluster:
+      package: vtds-cluster-mock
+      module: vtds_cluster_mock
+      source_type: git
+      metadata:
+        url: "git@github.com:Cray-HPE/vtds-cluster-mock.git"
+        version: main
+    application:
+      package: vtds-application-testrunner
+      module: vtds_application_testrunner
+      source_type: git
+      metadata:
+        url: "git@github.com:Cray-HPE/vtds-application-testrunner.git"
+        version: main
+  configurations:
+  - type: git
+    metadata:
+      # This brings in the HPE specific settings needed to build an HPE
+      # project on GCP.
+      repo: git@github.com:Cray-HPE/vtds-configs.git
+      version: main
+      path: layers/provider/gcp/provider-gcp-hpe-org.yaml
+  - type: git
+    metadata:
+      # This brings in the vTDS config for deploying the OpenCHAMI
+      # Tester project for use in running OpenCHAMI CI/CD Pipeline
+      # tests.
+      repo: git@github.com:Cray-HPE/vtds-configs.git
+      version: main
+      path: layers/provider/gcp/provider-gcp-openchami-tester.yaml
+  - type: git
+    metadata:
+      # This brings in the FSM / SCS Connectivity Demo configuration
+      # for the platform layer.
+      repo: git@github.com:Cray-HPE/vtds-configs.git
+      version: main
+      path: layers/platform/ubuntu/platform-ubuntu-openchami-tester.yaml
+  - type: git
+    metadata:
+      # This brings in the FSM / SCS Connectivity Demo configuration
+      # for the cluster layer.
+      repo: git@github.com:Cray-HPE/vtds-configs.git
+      version: main
+      path: layers/cluster/mock/cluster-mock-openchami-tester.yaml
+  - type: git
+    metadata:
+      # This brings in the FSM / SCS Connectivity Demo configuration
+      # for the application layer.
+      repo: git@github.com:Cray-HPE/vtds-configs.git
+      version: main
+      path: layers/application/ubuntu/application-ubuntu-openchami-tester.yaml
+  - type: command-line
+    # Bring in any configuration files / sources listed on the command
+    # line and merge them on top of what has been listed here. This
+    # overlay will override matching settings in the above sources.
+    metadata: {}
+  - type: core-config
+    # If there is anything outside the 'core' section of the Core
+    # Configuration apply it last to override anything seen up to this
+    # point.
+    metadata: {}
+provider:
+  terragrunt:
+    terraform_dummy_version: latest
+    terragrunt_dummy_version: latest
+  project:
+    base_name: openchami-test-runner
+    random_project_id: false

--- a/layers/application/ubuntu/application-ubuntu-openchami-tester.yaml
+++ b/layers/application/ubuntu/application-ubuntu-openchami-tester.yaml
@@ -1,0 +1,28 @@
+#
+# MIT License
+#
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Nothing here. All of the activity in the OpenCHAMI Tester takes place
+# on the single Virtual Blade. If there is an application layer at all,
+# besides 'mock' it will just set up the Virtual Blade to run openchami
+# tests on a separate vTDS deployed OpenCHAMI cluster.
+application: {}

--- a/layers/cluster/mock/cluster-mock-openchami-tester.yaml
+++ b/layers/cluster/mock/cluster-mock-openchami-tester.yaml
@@ -1,0 +1,31 @@
+#
+# MIT License
+#
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Cluster layer for a simple Ubuntu / KVM POC vTDS
+cluster:
+  host_blade_network:
+    blade_interconnect: mock-interconnect
+  networks:
+    example_network:
+      blade_interconnect: mock-interconnect
+

--- a/layers/platform/ubuntu/platform-ubuntu-openchami-tester.yaml
+++ b/layers/platform/ubuntu/platform-ubuntu-openchami-tester.yaml
@@ -1,0 +1,32 @@
+#
+# MIT License
+#
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Platform layer configuration for the simple Ubuntu cluster POC
+platform:
+  packages:
+    # Add podman for running containerized workflows, since testing
+    # workflows are likely to be containerized.
+    containers:
+      blade_classes: null
+      packages:
+        - podman

--- a/layers/provider/gcp/provider-gcp-openChami.yaml
+++ b/layers/provider/gcp/provider-gcp-openChami.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,14 +22,12 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 provider:
-  # There is a configuration file called
-  #
-  #   provider-gcp-hpe-org.yaml
-  #
-  # In this same directory that contains the organization settings for
-  # all HPE GCP based vTDS systems. Use that to set up the
-  # 'organization' and 'project' settings. Use this file to set up the
-  # rest of the POC configuration.
+  # This configuration provides the organization independent
+  # configuration for the GCP provider layer needed to run
+  # OpenCHAMI. Your organization should also provide the GCP
+  # organization specific configuration that allows deployment of
+  # resources into GCP.  See the 'vtds-provider-gcp' README.md file for
+  # more information on this.
   organization: {}
   project: {}
   blade_interconnects:

--- a/layers/provider/gcp/provider-gcp-openchami-tester.yaml
+++ b/layers/provider/gcp/provider-gcp-openchami-tester.yaml
@@ -1,0 +1,98 @@
+#
+# MIT License
+#
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# This configuration sets up a platform from which to run OpenCHAMI
+# tests from within GCP. This platform is super simple. It uses a single
+# GCP instance (Virtual Blade in vTDS parlance) as a bastion node for
+# running vTDS commands to create OpenCHAMI systems. There are no
+# Virtual Nodes in the system because they aren't needed and just add
+# time and complexity to setting things up. We are basically just
+# leveraging vTDS for deploying a simple GCP project with a single GCP
+# instance in it.
+provider:
+  # There is a configuration file called
+  #
+  #   provider-gcp-hpe-org.yaml
+  #
+  # In this same directory that contains the organization settings for
+  # all HPE GCP based vTDS systems. Since we are going to run this from
+  # within the HPE organization, Use that to set up the 'organization'
+  # and 'project' settings. Use this file to set up the rest of the test
+  # platform configuration.
+  organization: {}
+  project: {}
+  blade_interconnects:
+    mock-interconnect:
+      # A blade interconnect because we need to have one even though we
+      # won't be using it.
+      parent_class: base-interconnect
+      pure_base_class: false
+      network_name: "mock-interconnect"
+      description: |
+        A blade interconnect based on 'base interconnect' just so we
+        have one.
+      routes: []
+  virtual_blades:
+    # Host blade. This "blade" will be where we do all of our
+    # work. There will be just one of them and it will be small.
+    host-blade:
+      vm:
+        machine_type: n1-standard-4
+        boot_disk:
+          disk_size_gb: 100
+      service_account_iam:
+        # Need "roles/billing.user" on 'billing' to permit the SA to
+        # create new vTDS clusters.
+        billing:
+          - "roles/billing.user"
+        # Need
+        #    "roles/resourcemanager.folderViewer"
+        #    "roles/resourcemanager.projectCreator"
+        # on the Clusters Folder to permit the SA to create new vTDS clusters
+        clusters_folder:
+          - "roles/resourcemanager.folderViewer"
+          - "roles/resourcemanager.projectCreator"
+        # Need "roles/resourcemanager.organizationViewer" on the
+        # organization to permit the SA to create new vTDS clusters.
+        organization:
+          - "roles/resourcemanager.organizationViewer"
+        # Need
+        #    "roles/secretmanager.secretAccessor"
+        #    "roles/secretmanager.secretVersionManager"
+        #    "roles/storage.admin"
+        #    "roles/viewer"
+        # on the Seed Project to permit the SA to create new vTDS clusters.
+        seed_project:
+          - "roles/secretmanager.secretAccessor"
+          - "roles/secretmanager.secretVersionManager"
+          - "roles/storage.admin"
+          - "roles/viewer"
+      parent_class: base-blade
+      pure_base_class: false
+      blade_interconnect:
+        subnetwork: "mock-interconnect"
+        ip_addrs:
+        - 10.255.1.1
+      count: 1
+      name_prefix: "openchami-tester"
+      hostname: openchami-tester


### PR DESCRIPTION
## Summary and Scope

This PR creates configuration for a vtds-application-testrunner system that can be used as a bastion server for automatically deploying vTDS clusters to run automated tests.

## Issues and Related PRs

* Resolves [VSHA-708](https://jira-pro.it.hpe.com:8443/browse/VSHA-708)

## Testing

Used this configuration to deploy a vtds-application-testrunner system and use it to deploy a vTDS OpenCHAMI test runner.